### PR TITLE
Fix compile error with flex >= 2.5.36

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -135,6 +135,23 @@ if test "${LEX}" = "flex"; then
   AC_DEFINE(HAVE_FLEX,1,[using flex, rather than lex])
 fi
 
+# flex >= 2.5.36 uses a nonstandard type for yyleng
+AC_MSG_CHECKING([whether yyleng is yy_size_t])
+cat > conftest.l <<EOF
+%%
+%%
+yy_size_t yyleng;
+EOF
+$LEX conftest.l
+AC_COMPILE_IFELSE([AC_LANG_DEFINES_PROVIDED [`cat $LEX_OUTPUT_ROOT.c`]], [
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(YYLENG_IS_YY_SIZE_T,1,
+    [Define to 1 if lex declares yyleng to be yy_size_t.])
+], [
+  AC_MSG_RESULT(no)
+])
+rm -f conftest.l $LEX_OUTPUT_ROOT.c
+
 # get packages we need
 # gtk before 2.4.9 crashes with the way we use combobox :-(
 PKG_CHECK_MODULES(REQUIRED_PACKAGES, 

--- a/src/parser.h
+++ b/src/parser.h
@@ -55,7 +55,13 @@ extern InputState input_state;
 void nip2yyerror( const char *sub, ... )
 	__attribute__((format(printf, 1, 2)));
 void yyerror( const char *msg ); 
+#ifdef YYLENG_IS_YY_SIZE_T
+/* Assume yy_size_t is size_t.
+ */
+extern size_t yyleng;
+#else
 extern int yyleng;			/* lex stuff */
+#endif
 
 /* Lex gathers tokens here for workspace.c
  */


### PR DESCRIPTION
Newer flex declares yyleng to be yy_size_t (== size_t), contrary to SuS.
