### PR TITLE
Simplify nip2-icon.o build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ src/gtksheet-marshal.c
 src/gtksheettypebuiltins.c
 src/lex.c
 src/nip2
-src/nip2-icon.rc
 src/parse.c
 src/parse.h
 stamp-h1

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ po/POTFILES
 fred
 po/Makefile.in.in
 src/.deps/
-src/dummy.c
 src/gtksheet-marshal.c
 src/gtksheettypebuiltins.c
 src/lex.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -40,7 +40,6 @@ src/parse.c
 src/managedgvalue.c
 src/conversion.c
 src/trace.c
-src/dummy.c
 src/gtkutil.c
 src/slider.c
 src/action.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -304,9 +304,6 @@ nipmarshal.c:
 	echo "#include \"nipmarshal.h\"" > nipmarshal.c 
 	glib-genmarshal --prefix=nip --body nipmarshal.list >> nipmarshal.c
 
-nip2-icon.rc:
-	echo 1 ICON \"nip2-icon.ico\" > nip2-icon.rc
-
 .rc.o:
 if OS_WIN32 
 	cp ${top_srcdir}/share/nip2/data/nip2-icon.ico .

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -184,7 +184,6 @@ nip2_SOURCES = \
 	plotwindow.h \
 	model.c \
 	model.h \
-	nip2-icon.rc \
 	option.c \
 	option.h \
 	optionview.c \
@@ -296,6 +295,11 @@ nip2_SOURCES = \
 	workspaceview.c \
 	workspaceview.h 
 
+if OS_WIN32
+nip2_SOURCES += \
+	nip2-icon.rc
+endif
+
 helpindex.h: 
 	./makehelpindex.pl $(prefix) > helpindex.h
 nipmarshal.h:
@@ -305,13 +309,8 @@ nipmarshal.c:
 	glib-genmarshal --prefix=nip --body nipmarshal.list >> nipmarshal.c
 
 .rc.o:
-if OS_WIN32 
 	cp ${top_srcdir}/share/nip2/data/nip2-icon.ico .
 	${WINDRES} $< -o $@ 
-else
-	echo "int poop () {}" >dummy.c 
-	$(CC) -c dummy.c -o $@
-endif
 
 # we have to replace the standard .y.c rule: we are a bison-only GLR parser,
 # so we can't use autoconf's preferred -y yacc-compatibility stuff

--- a/src/nip2-icon.rc
+++ b/src/nip2-icon.rc
@@ -1,0 +1,1 @@
+1 ICON "nip2-icon.ico"


### PR DESCRIPTION
Don't generate `nip2-icon.rc` at build time, and only build `nip2-icon.o` on Windows.  Fixes warning when building on MacPorts:

    dummy.c:1:14: warning: control reaches end of non-void function [-Wreturn-type]

Fixes `make dist` failure if run before `make`:

    make[2]: *** No rule to make target '../src/dummy.c', needed by 'nip2.pot'.  Stop.

Tested on a Linux build, but **not** on a Windows build.