### PR TITLE
Fix building with gcc 15

### DIFF
--- a/src/ip.h
+++ b/src/ip.h
@@ -108,7 +108,6 @@
 #endif /*HAVE_SYS_STATVFS_H*/
 #ifdef HAVE_SYS_VFS_H
 #include <sys/vfs.h>
-extern int statfs();
 #endif /*HAVE_SYS_VFS_H*/
 #ifdef HAVE_SYS_MOUNT_H
 #include <sys/mount.h>

--- a/src/plot.c
+++ b/src/plot.c
@@ -375,7 +375,7 @@ plot_class_get( Classmodel *classmodel, PElement *root )
 	Imageinfo *ii2;
 	IMAGE *t;
 	DOUBLEMASK *mask;
-	int (*fn)();
+	int (*fn)(VipsImage *, VipsImage *);
 
 	/* nx1 or 1xm images only ... use Bands for columns.
 	 */


### PR DESCRIPTION
gcc 15 enforces function type arguments.  This fixes compilation errors seen with it.